### PR TITLE
Switch from babel-register to @babel/register

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 db-migrate-plugin-babel
 =======================
 
-Simply install 'babel-register' and this plugin and `db-migrate` should pick it up automatically.
+Simply install either `babel-register` or `@babel/register` along with `db-migarte` and this plugin
+should pick it up automatically.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 db-migrate-plugin-babel
 =======================
 
-Add babel support to db-migrate via `babel-register`.
-
 Simply install 'babel-register' and this plugin and `db-migrate` should pick it up automatically.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 db-migrate-plugin-babel
 =======================
 
-Simply install either `babel-register` or `@babel/register` along with `db-migarte` and this plugin
-should pick it up automatically.
+Simply install either `babel-register` or `@babel/register` and `db-migrate` should pick it up
+automatically.

--- a/index.js
+++ b/index.js
@@ -8,7 +8,20 @@ Object.assign(exports, {
   ],
   loadPlugin: function() {
     exports['migrator:migration:hook:require'] = function() {
-      require('@babel/register');
+
+      try {
+        require('@babel/register');
+      }
+      catch (error) {
+
+        try {
+          require('babel-register');
+        }
+        catch {
+          throw new Error("You must include either babel-register or @babel/register in your "
+            + "package.json file.");
+        }
+      }
     };
 
     // loadPlugin can be called multiple times, so we unload it here to save precious cycles

--- a/index.js
+++ b/index.js
@@ -18,8 +18,7 @@ Object.assign(exports, {
           require('babel-register');
         }
         catch {
-          throw new Error("You must include either babel-register or @babel/register in your "
-            + "package.json file.");
+          throw new Error("You must install either babel-register or @babel/register");
         }
       }
     };

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ Object.assign(exports, {
   ],
   loadPlugin: function() {
     exports['migrator:migration:hook:require'] = function() {
-      require('babel-register');
+      require('@babel/register');
     };
 
     // loadPlugin can be called multiple times, so we unload it here to save precious cycles

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "index.js"
   ],
   "peerDependencies": {
-    "db-migrate": "*",
-    "@babel/register": "*"
+    "db-migrate": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,5 +28,9 @@
   "homepage": "https://github.com/benjie/db-migrate-plugin-babel#readme",
   "files": [
     "index.js"
-  ]
+  ],
+  "peerDependencies": {
+    "db-migrate": "*",
+    "@babel/register": "*"
+  }
 }


### PR DESCRIPTION
This seems to work fine for me locally. I also added peer dependencies for `db-migrate` and `@babel/register` while I was at it.