### PR TITLE
Fixed syntax error

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ Object.assign(exports, {
         try {
           require('babel-register');
         }
-        catch {
+        catch (ex) {
           throw new Error("You must install either babel-register or @babel/register");
         }
       }


### PR DESCRIPTION
Node < v10 does not support Optional Catch Binding, so SyntaxError occurs

```
[WARN] /node_modules/db-migrate-plugin-babel/index.js:20
        catch {
              ^

SyntaxError: Unexpected token {
    at createScript (vm.js:80:10)
    at Object.runInThisContext (vm.js:139:10)
    at Module._compile (module.js:616:28)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
    at Module.require (module.js:596:17)
    at require (internal/module.js:11:18)
    at loadPlugins (/node_modules/db-migrate/index.js:30:18)
```