### PR TITLE
Fix migrator:migration hook deprecation

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,10 +4,10 @@
 Object.assign(exports, {
   name: 'babel',
   hooks: [
-    'migrator:migration:hook:require',
+    'file:hook:require',
   ],
   loadPlugin: function() {
-    exports['migrator:migration:hook:require'] = function() {
+    exports['file:hook:require'] = function() {
 
       try {
         require('@babel/register');


### PR DESCRIPTION
This pull request addresses the following warning:
```
[WARN] The plugin 'db-migrate-plugin-babel' is outdated! The hookmigrator:migration:hook:require was deprecated!
[WARN] Report the maintainer of 'db-migrate-plugin-babel' to patch the hook instead with file:hook:require.
```